### PR TITLE
Find and replace dialog as QWidget instead of hard-coded QDialog

### DIFF
--- a/include/KGL/Widgets/QCodeEditor.hpp
+++ b/include/KGL/Widgets/QCodeEditor.hpp
@@ -322,7 +322,7 @@ namespace kgl {
         QSortFilterProxyModel *m_RuleFilter;    ///< Filters all the keywords, funcs, ...
         QCompleter *m_AutoComplete;             ///< Auto completion widget
         qint32 m_CompletionTrigger;             ///< Amount of characters till AC trigger
-        QCodeEditorTextFinder *m_TextFinder;    ///< Find and replace text widget
+        QDialog *m_TextFinder;                  ///< Find and replace text widget
 
         // Allow the line widget to access vars/funcs while rendering
         friend class QCodeEditorLineWidget;

--- a/include/KGL/Widgets/QCodeEditorTextFinder.hpp
+++ b/include/KGL/Widgets/QCodeEditorTextFinder.hpp
@@ -48,6 +48,13 @@ namespace kgl {
         ///
         static QDialog *makeDialog(QCodeEditor *codeEditor);
 
+        ///
+        ///  @fn      setReplaceAsFocusProxy
+        ///  @brief   Allows choose if find or replace QLineEdit is this widgets focus proxy.
+        ///  @param   `true` to make replace, `false` to make find as the widgets focus proxy.
+        ///
+        void setReplaceAsFocusProxy(bool value);
+
     private slots:
 
         ///

--- a/include/KGL/Widgets/QCodeEditorTextFinder.hpp
+++ b/include/KGL/Widgets/QCodeEditorTextFinder.hpp
@@ -23,7 +23,7 @@ namespace kgl {
     ///  @author    Marek Bula
     ///  @date      February 16th, 2086
     ///  @class     QCodeEditorTextFinder
-    ///  @brief     Simple 'search and replace' dialog window.
+    ///  @brief     Simple 'search and replace' dialog widget.
     ///
     class KGL_API QCodeEditorTextFinder : public QWidget{
     Q_OBJECT
@@ -33,7 +33,7 @@ namespace kgl {
         ///  @fn    Constructor
         ///  @brief Initializes a new instance of QCodeEditorTextFinder.
         ///
-        QCodeEditorTextFinder(QCodeEditor *parent);
+        QCodeEditorTextFinder(QWidget *parent, QCodeEditor *codeEditor);
 
         ///
         ///  @fn    Destructor
@@ -42,10 +42,11 @@ namespace kgl {
         ~QCodeEditorTextFinder();
 
         ///
-        ///  @fn    show
-        ///  @brief Shows 'search and replace' dialog window.
+        ///  @fn      makeDialog : static
+        ///  @brief   Make dialog that wraps search and replace widget.
+        ///  @returns a pointer to a new dialog instance.
         ///
-        void show();
+        static QDialog *makeDialog(QCodeEditor *codeEditor);
 
     private slots:
 
@@ -121,8 +122,7 @@ namespace kgl {
         ///
         void updateInfoLabel();
 
-        QDialog* m_FindDialog;
-        QCodeEditor *m_Parent;
+        QCodeEditor *m_Editor;
         QGridLayout *m_DialogLayout;
         QPushButton *m_ReplaceButton;
         QPushButton *m_ReplaceAllButton;

--- a/src/Widgets/QCodeEditor.cpp
+++ b/src/Widgets/QCodeEditor.cpp
@@ -86,7 +86,7 @@ namespace kgl {
         updateLineColumn(0);
 
         // Constructs textFinder widget
-        m_TextFinder = new QCodeEditorTextFinder(this);
+        m_TextFinder = QCodeEditorTextFinder::makeDialog(this);
 
         // Connects signals with slots
         connect(m_AutoComplete, SIGNAL(activated(QString)), this, SLOT(completeWord(QString)));

--- a/src/Widgets/QCodeEditor.cpp
+++ b/src/Widgets/QCodeEditor.cpp
@@ -66,7 +66,7 @@ namespace kgl {
         m_Popup = new QCodeEditorPopup(this);
 
         // Constructs the intelliBox's completer
-        m_AutoComplete = new QCompleter;
+        m_AutoComplete = new QCompleter(this);
         m_AutoComplete->setWidget(this);
         m_AutoComplete->setCompletionMode(QCompleter::PopupCompletion);
         m_AutoComplete->setModelSorting(QCompleter::CaseInsensitivelySortedModel);
@@ -76,7 +76,7 @@ namespace kgl {
         m_SourceModel = new QStandardItemModel;
 
         // Constructs the sorting proxy model
-        m_RuleFilter = new QSortFilterProxyModel;
+        m_RuleFilter = new QSortFilterProxyModel(this);
         m_RuleFilter->setFilterCaseSensitivity(Qt::CaseInsensitive);
         m_RuleFilter->setDynamicSortFilter(false);
 
@@ -100,10 +100,6 @@ namespace kgl {
     ///  @author    Nicolas Kogler
     ///
     QCodeEditor::~QCodeEditor() {
-        delete m_Highlighter;
-        delete m_LineWidget;
-        delete m_RuleFilter;
-        delete m_AutoComplete;
     }
 
 

--- a/src/Widgets/QCodeEditorEvents.cpp
+++ b/src/Widgets/QCodeEditorEvents.cpp
@@ -272,7 +272,7 @@ namespace kgl {
     ///  @date      October 5th, 2016
     ///
     void QCodeEditor::resizeEvent(QResizeEvent *event) {
-        Q_UNUSED(event);
+        QPlainTextEdit::resizeEvent(event);
 
         // Makes space for the line widget
         if (m_Design.isLineColumnVisible()) {

--- a/src/Widgets/QCodeEditorTextFinder.cpp
+++ b/src/Widgets/QCodeEditorTextFinder.cpp
@@ -45,6 +45,8 @@ QCodeEditorTextFinder::QCodeEditorTextFinder(QWidget* parent, QCodeEditor *codeE
         m_CurrentSelectionIdx = 0;
         m_CurrentSelectionRemoved = false;
         m_FoundCount = 0;
+
+        setReplaceAsFocusProxy(false);
     }
 
     ///
@@ -66,6 +68,16 @@ QCodeEditorTextFinder::QCodeEditorTextFinder(QWidget* parent, QCodeEditor *codeE
         dialog->layout()->addWidget(finder);
         connect(dialog, SIGNAL(rejected()), finder, SLOT(clearSelections()));
         return dialog;
+    }
+
+    ///
+    ///  @fn        makeDialog
+    ///  @author    Mariusz Jaskolka
+    ///
+    void QCodeEditorTextFinder::setReplaceAsFocusProxy(bool value)
+    {
+        QWidget* focusProxyWidget = value ? m_TextToReplace : m_TextToFind;
+        setFocusProxy(focusProxyWidget);
     }
 
     ///


### PR DESCRIPTION
* Fix some memory leaks
* Fix double delete crash
* Do not put `find and replace` dialog inside QDialog (but still possible)