### PR TITLE
Make cmake relative-path-agnostic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ else()
     set(QCODEEDITOR_LIBRARY qcodeeditor${QCODEEDITOR_VERSION_MAJOR})
 endif()
 
-set(QCODEEDITOR_INCLUDE_ROOT ${CMAKE_SOURCE_DIR}/include)
-set(QCODEEDITOR_RESOURCE_ROOT ${CMAKE_SOURCE_DIR}/resources)
+set(QCODEEDITOR_INCLUDE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set(QCODEEDITOR_RESOURCE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/resources)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
@@ -64,12 +64,12 @@ else()
     set(QCODEEDITOR_LIBRARY_TYPE STATIC)
 endif()
 
-add_subdirectory(src)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 if (QCODEEDITOR_BUILD_EXAMPLES)
-    add_subdirectory(examples)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
 endif()
 
 #if (QCODEEDITOR_BUILD_DOCS)
-#    add_subdirectory(docs)
+#    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/docs)
 #endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,15 +21,15 @@
 ]]
 
 set(SOURCES
-    QCodeEditor.cpp
-    QCodeEditorDesign.cpp
-    QCodeEditorHighlighter.cpp
-    QCodeEditorLineWidget.cpp
-    QCodeEditorPopup.cpp
-    QCodeEditorStyleSheets.cpp
-    QCodeEditorTextFinder.cpp
-    QSyntaxRule.cpp
-    XmlHelper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCodeEditor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCodeEditorDesign.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCodeEditorHighlighter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCodeEditorLineWidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCodeEditorPopup.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCodeEditorStyleSheets.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCodeEditorTextFinder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QSyntaxRule.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/XmlHelper.cpp
 )
 
 set(HEADERS
@@ -41,8 +41,8 @@ set(HEADERS
     ${QCODEEDITOR_INCLUDE_ROOT}/QCodeEditor/QCodeEditorPopup.hpp
     ${QCODEEDITOR_INCLUDE_ROOT}/QCodeEditor/QCodeEditorTextFinder.hpp
     ${QCODEEDITOR_INCLUDE_ROOT}/QCodeEditor/QSyntaxRule.hpp
-    QCodeEditorStyleSheets.hpp
-    XmlHelper.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/QCodeEditorStyleSheets.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/XmlHelper.hpp
 )
 
 qt5_add_resources(RESOURCES ${QCODEEDITOR_RESOURCE_ROOT}/resources.qrc)


### PR DESCRIPTION
It makes it possible to use library in own CMakeLists.txt e.g. just by adding:
`add_subdirectory(ThirdParty/QCodeEditor)`